### PR TITLE
feat: add requestMapper option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.log
 node_modules
 dist
+package
 coverage
 
 # Trailing dotted files

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,5 @@
 package.json
 package-lock.json
 dist/
+package/
 coverage/

--- a/README.md
+++ b/README.md
@@ -81,18 +81,40 @@ import { createMSWInspector } from 'msw-inspector';
 createMSWInspector({
   mockSetup, // Any `msw` SetupServerApi or SetupWorkerApi instance
   mockFactory, // Function returning a mocked function instance to be inspected in your tests
+  requestMapper, // Optional mapper function to customize how requests are stored
 });
 ```
 
+#### Options object
+
+`createMSWInspector` accepts the following options object:
+
+```ts
+ {
+  mockSetup: SetupServerApi | SetupWorkerApi;
+  mockFactory: () => FunctionMock;
+  requestMapper?: (req: MockedRequest) => {
+    key: string;
+    record: Record<string, any>;
+  };
+}
+```
+
+| Option                       | Description                                                                                                                                                                         | Default value                                  |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **mockSetup** _(required)_   | The instance of `msw` mocks expected to inspect _([`setupWorker`][msw-docs-setup-worker] or [`setupServer`][msw-docs-setup-server] result)_                                         | -                                              |
+| **mockFactory** _(required)_ | A function returning the function mock preferred by your testing framework: It can be `() => jest.fn()` for Jest, `() => sinon.spy()` for Sinon, `() => vi.fn()` for Vitest, etc... | -                                              |
+| **requestMapper**            | Customize default request's key and record mapping with your own logic.                                                                                                             | See [`defaultRequestMapper`](src/index.ts#L11) |
+
 ### `getRequests`
 
-Returns a mocked function containing all the calls intercepted for the given absolute url:
+Returns a mocked function containing all the calls intercepted at the given absolute url (by default):
 
 ```ts
 mswInspector.getRequests('http://my.url/path');
 ```
 
-Each intercepted request calls the matching mocked function with the following payload:
+Each intercepted request calls the matching mocked function with the following default payload:
 
 ```ts
 type CallPayload = {

--- a/package.json
+++ b/package.json
@@ -70,11 +70,11 @@
   },
   "lint-staged": {
     "**/*.{js,json}": [
-      "prettier",
-      "npm t"
+      "npm run prettier",
+      "npm run test:source"
     ],
     "**/*.md": [
-      "prettier"
+      "npm run prettier"
     ]
   },
   "engines": {

--- a/src/__tests__/__mocks__/handlers.ts
+++ b/src/__tests__/__mocks__/handlers.ts
@@ -1,10 +1,10 @@
 import { rest } from 'msw';
 
 export const handlers = [
-  rest.get('http://absolute.path', (req, res, ctx) => {
+  rest.get('http://absolute.path/*', (req, res, ctx) => {
     return res(ctx.status(200));
   }),
-  rest.post('http://absolute.path', (req, res, ctx) => {
+  rest.post('http://absolute.path/*', (req, res, ctx) => {
     return res(ctx.status(200));
   }),
 ];

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -2,59 +2,103 @@ import fetch from 'node-fetch';
 import { createMSWInspector } from '../index';
 import { server } from './__mocks__/server';
 
-const mswInspector = createMSWInspector({
-  mockSetup: server,
-  mockFactory: () => jest.fn(),
-});
-
-beforeAll(() => {
-  mswInspector.setup();
-});
-
-beforeEach(() => {
-  mswInspector.clear();
-});
-
-afterAll(() => {
-  mswInspector.teardown();
-});
-
 describe('getRequests', () => {
-  it('returns a mocked function with mathching intercepted calls for a given path', async () => {
-    await fetch('http://absolute.path?name=foo', {
-      method: 'POST',
-      body: JSON.stringify({ surname: 'bar' }),
+  describe('default options', () => {
+    const mswInspector = createMSWInspector({
+      mockSetup: server,
+      mockFactory: () => jest.fn(),
     });
 
-    expect(
-      mswInspector.getRequests('http://absolute.path/')
-    ).toHaveBeenCalledWith({
-      method: 'POST',
-      headers: {
-        accept: '*/*',
-        'accept-encoding': 'gzip,deflate',
-        connection: 'close',
-        'content-length': '17',
-        'content-type': 'text/plain;charset=UTF-8',
-        host: 'absolute.path',
-        'user-agent': 'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
-      },
-      body: JSON.stringify({ surname: 'bar' }),
-      query: {
-        name: 'foo',
-      },
+    beforeAll(() => {
+      mswInspector.setup();
+    });
+
+    beforeEach(() => {
+      mswInspector.clear();
+    });
+
+    afterAll(() => {
+      mswInspector.teardown();
+    });
+
+    it('returns a mocked function with matching intercepted calls for a given path', async () => {
+      await fetch('http://absolute.path?name=foo', {
+        method: 'POST',
+        body: JSON.stringify({ surname: 'bar' }),
+      });
+
+      expect(
+        mswInspector.getRequests('http://absolute.path/')
+      ).toHaveBeenCalledWith({
+        method: 'POST',
+        headers: {
+          accept: '*/*',
+          'accept-encoding': 'gzip,deflate',
+          connection: 'close',
+          'content-length': '17',
+          'content-type': 'text/plain;charset=UTF-8',
+          host: 'absolute.path',
+          'user-agent':
+            'node-fetch/1.0 (+https://github.com/bitinn/node-fetch)',
+        },
+        body: JSON.stringify({ surname: 'bar' }),
+        query: {
+          name: 'foo',
+        },
+      });
+    });
+
+    describe('no matching calls', () => {
+      it('throw expected error', async () => {
+        await fetch('http://absolute.path');
+
+        expect(() =>
+          mswInspector.getRequests('http://it.was.never.called/')
+        ).toThrowError(
+          '[msw-inspector] Cannot find a matching requests for path: http://it.was.never.called/. Intercepted requests paths are:\n\nhttp://absolute.path'
+        );
+      });
     });
   });
 
-  describe('no matching calls', () => {
-    it('throw expected error', async () => {
-      await fetch('http://absolute.path');
+  describe('requestMapper option', () => {
+    const mswInspector = createMSWInspector({
+      mockSetup: server,
+      mockFactory: () => jest.fn(),
+      requestMapper: (req) => {
+        const { method } = req;
+        const { pathname } = req.url;
 
-      expect(() =>
-        mswInspector.getRequests('http://it.was.never.called/')
-      ).toThrowError(
-        '[msw-inspector] Cannot find a matching requests for path: http://it.was.never.called/. Intercepted requests paths are:\n\nhttp://absolute.path'
-      );
+        return {
+          key: pathname,
+          record: {
+            method,
+          },
+        };
+      },
+    });
+
+    beforeAll(() => {
+      mswInspector.setup();
+    });
+
+    beforeEach(() => {
+      mswInspector.clear();
+    });
+
+    afterAll(() => {
+      mswInspector.teardown();
+    });
+
+    it('replaces default mapping behavior', async () => {
+      await fetch('http://absolute.path/path-name', {
+        method: 'POST',
+        body: JSON.stringify({ surname: 'bar' }),
+      });
+
+      expect(mswInspector.getRequests('/path-name')).toHaveBeenCalledWith({
+        method: 'POST',
+      });
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ type RequestLogRecord = {
   query?: Record<string, string>;
 };
 
-function requestMapper(req: MockedRequest): {
+function defaultRequestMapper(req: MockedRequest): {
   key: string;
   record: RequestLogRecord;
 } {
@@ -39,9 +39,14 @@ function requestMapper(req: MockedRequest): {
 function createMSWInspector<FunctionMock extends Function>({
   mockSetup,
   mockFactory,
+  requestMapper = defaultRequestMapper,
 }: {
   mockSetup: SetupServerApi | SetupWorkerApi;
   mockFactory: () => FunctionMock;
+  requestMapper?: (req: MockedRequest) => {
+    key: string;
+    record: Record<string, any>;
+  };
 }) {
   // Store network requests by url
   const requestLog = new Map<string, FunctionMock>();


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

Requests are stored by absolute url and inspectionable payload is not configurable.

## What is the new behaviour?

Accept a `requestMapper` function to customize stored request key and payload

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
