### PR TITLE
feat: progressive `requestMapper` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ createMSWInspector({
 | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
 | **mockSetup** _(required)_   | The instance of `msw` mocks expected to inspect _([`setupWorker`][msw-docs-setup-worker] or [`setupServer`][msw-docs-setup-server] result)_                                         | -                                       |
 | **mockFactory** _(required)_ | A function returning the function mock preferred by your testing framework: It can be `() => jest.fn()` for Jest, `() => sinon.spy()` for Sinon, `() => vi.fn()` for Vitest, etc... | -                                       |
-| **requestMapper**            | Customize default request's key and record mapping with your own logic. Async function.                                                                                             | See [`requestMapper`](src/index.ts#L54) |
+| **requestMapper**            | Customize default request's key and record mapping with your own logic. Async function.                                                                                             | See [`requestMapper`](src/index.ts#L15) |
 
 ### `getRequests`
 
@@ -121,15 +121,36 @@ Returns a mocked function containing all the calls intercepted at the given abso
 mswInspector.getRequests('http://my.url/path');
 ```
 
-By default each intercepted request calls the matching mocked function with the following default payload:
+By default each intercepted request calls the matching mocked function with the following request log record:
 
 ```ts
-type CallPayload = {
+type DefaultRequestLogRecord = {
   method: string;
   headers: Record<string, string>;
   body?: any;
   query?: Record<string, string>;
 };
+```
+
+If you want to create a different log record you can do so by providing a custom `requestMapper`:
+
+```ts
+import { createMSWInspector, defaultRequestMapper } from 'msw-inspector';
+
+const mswInspector = createMSWInspector({
+  requestMapper: async (req) => {
+    // Optionally use the default request mapper to get the default request object
+    const defaultLog = await defaultRequestMapper(req);
+
+    return {
+      key: pathname,
+      record: {
+        myMethodProp: req.method,
+        myBodyProp: defaultLog.record.body,
+      },
+    };
+  },
+});
 ```
 
 ## Todo

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ afterAll(() => {
 
 describe('My test', () => {
   it('My test', async () => {
-    // Perform your test preparation
+    // Perform your tests
 
     expect(mswInspector.getRequests('http://my.url/path')).toHaveBeenCalledWith(
       {
@@ -107,11 +107,11 @@ createMSWInspector({
 }
 ```
 
-| Option                       | Description                                                                                                                                                                         | Default value                                  |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| **mockSetup** _(required)_   | The instance of `msw` mocks expected to inspect _([`setupWorker`][msw-docs-setup-worker] or [`setupServer`][msw-docs-setup-server] result)_                                         | -                                              |
-| **mockFactory** _(required)_ | A function returning the function mock preferred by your testing framework: It can be `() => jest.fn()` for Jest, `() => sinon.spy()` for Sinon, `() => vi.fn()` for Vitest, etc... | -                                              |
-| **requestMapper**            | Customize default request's key and record mapping with your own logic. Async function.                                                                                             | See [`defaultRequestMapper`](src/index.ts#L11) |
+| Option                       | Description                                                                                                                                                                         | Default value                           |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **mockSetup** _(required)_   | The instance of `msw` mocks expected to inspect _([`setupWorker`][msw-docs-setup-worker] or [`setupServer`][msw-docs-setup-server] result)_                                         | -                                       |
+| **mockFactory** _(required)_ | A function returning the function mock preferred by your testing framework: It can be `() => jest.fn()` for Jest, `() => sinon.spy()` for Sinon, `() => vi.fn()` for Vitest, etc... | -                                       |
+| **requestMapper**            | Customize default request's key and record mapping with your own logic. Async function.                                                                                             | See [`requestMapper`](src/index.ts#L54) |
 
 ### `getRequests`
 
@@ -121,7 +121,7 @@ Returns a mocked function containing all the calls intercepted at the given abso
 mswInspector.getRequests('http://my.url/path');
 ```
 
-Each intercepted request calls the matching mocked function with the following default payload:
+By default each intercepted request calls the matching mocked function with the following default payload:
 
 ```ts
 type CallPayload = {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,24 +1,24 @@
-import { createMSWInspector } from '../index';
+import { createMSWInspector, MswInspector } from '../index';
 import { server } from './__mocks__/server';
 
+const mswInspector: MswInspector = createMSWInspector({
+  mockSetup: server,
+  mockFactory: () => jest.fn(),
+});
+
+beforeAll(() => {
+  mswInspector.setup();
+});
+
+beforeEach(() => {
+  mswInspector.clear();
+});
+
+afterAll(() => {
+  mswInspector.teardown();
+});
+
 describe('getRequests', () => {
-  const mswInspector = createMSWInspector({
-    mockSetup: server,
-    mockFactory: () => jest.fn(),
-  });
-
-  beforeAll(() => {
-    mswInspector.setup();
-  });
-
-  beforeEach(() => {
-    mswInspector.clear();
-  });
-
-  afterAll(() => {
-    mswInspector.teardown();
-  });
-
   describe.each([
     {
       body: JSON.stringify({ hello: 'world' }),
@@ -75,47 +75,6 @@ describe('getRequests', () => {
       ).toThrowError(
         '[msw-inspector] Cannot find a matching requests for path: http://it.was.never.called/. Intercepted requests paths are:\n\nhttp://absolute.path'
       );
-    });
-  });
-
-  describe('requestMapper option', () => {
-    const mswInspector = createMSWInspector({
-      mockSetup: server,
-      mockFactory: () => jest.fn(),
-      requestMapper: async (req) => {
-        const { method } = req;
-        const { pathname } = req.url;
-
-        return {
-          key: pathname,
-          record: {
-            method,
-          },
-        };
-      },
-    });
-
-    beforeAll(() => {
-      mswInspector.setup();
-    });
-
-    beforeEach(() => {
-      mswInspector.clear();
-    });
-
-    afterAll(() => {
-      mswInspector.teardown();
-    });
-
-    it('replaces default mapping behavior', async () => {
-      await fetch('http://absolute.path/path-name', {
-        method: 'POST',
-        body: JSON.stringify({ surname: 'bar' }),
-      });
-
-      expect(mswInspector.getRequests('/path-name')).toHaveBeenCalledWith({
-        method: 'POST',
-      });
     });
   });
 });

--- a/src/__tests__/requestMapperOption.test.ts
+++ b/src/__tests__/requestMapperOption.test.ts
@@ -4,14 +4,16 @@ import { server } from './__mocks__/server';
 const mswInspector: MswInspector = createMSWInspector({
   mockSetup: server,
   mockFactory: () => jest.fn(),
-  requestMapper: async (req) => {
+  requestMapper: async ({ req, record, key }) => {
     const { method } = req;
     const { pathname } = req.url;
+    const { body } = record;
 
     return {
       key: pathname,
       record: {
         method,
+        customBodyProp: body,
       },
     };
   },
@@ -38,6 +40,7 @@ describe('requestMapper option', () => {
 
     expect(mswInspector.getRequests('/path-name')).toHaveBeenCalledWith({
       method: 'POST',
+      customBodyProp: { surname: 'bar' },
     });
   });
 });

--- a/src/__tests__/requestMapperOption.test.ts
+++ b/src/__tests__/requestMapperOption.test.ts
@@ -1,0 +1,43 @@
+import { createMSWInspector, MswInspector } from '../index';
+import { server } from './__mocks__/server';
+
+const mswInspector: MswInspector = createMSWInspector({
+  mockSetup: server,
+  mockFactory: () => jest.fn(),
+  requestMapper: async (req) => {
+    const { method } = req;
+    const { pathname } = req.url;
+
+    return {
+      key: pathname,
+      record: {
+        method,
+      },
+    };
+  },
+});
+
+beforeAll(() => {
+  mswInspector.setup();
+});
+
+beforeEach(() => {
+  mswInspector.clear();
+});
+
+afterAll(() => {
+  mswInspector.teardown();
+});
+
+describe('requestMapper option', () => {
+  it('replaces default mapping behavior', async () => {
+    await fetch('http://absolute.path/path-name', {
+      method: 'POST',
+      body: JSON.stringify({ surname: 'bar' }),
+    });
+
+    expect(mswInspector.getRequests('/path-name')).toHaveBeenCalledWith({
+      method: 'POST',
+    });
+  });
+});

--- a/src/__tests__/requestMapperOption.test.ts
+++ b/src/__tests__/requestMapperOption.test.ts
@@ -1,13 +1,19 @@
-import { createMSWInspector, MswInspector } from '../index';
+import {
+  createMSWInspector,
+  defaultRequestMapper,
+  MswInspector,
+} from '../index';
 import { server } from './__mocks__/server';
 
 const mswInspector: MswInspector = createMSWInspector({
   mockSetup: server,
   mockFactory: () => jest.fn(),
-  requestMapper: async ({ req, record, key }) => {
+  requestMapper: async (req) => {
     const { method } = req;
     const { pathname } = req.url;
-    const { body } = record;
+    const {
+      record: { body },
+    } = await defaultRequestMapper(req);
 
     return {
       key: pathname,

--- a/src/defaultRequestMapper.ts
+++ b/src/defaultRequestMapper.ts
@@ -1,0 +1,41 @@
+import qs from 'qs';
+import type { MockedRequest } from 'msw';
+
+export type DefaultRequestLogRecord = {
+  method: string;
+  headers: Record<string, string>;
+  body?: any;
+  query?: Record<string, string>;
+};
+
+export async function defaultRequestMapper(req: MockedRequest): Promise<{
+  key: string;
+  record: DefaultRequestLogRecord;
+}> {
+  const { method, headers } = req;
+  const { protocol, host, pathname, search } = req.url;
+
+  // @TODO review key generation
+  const key = protocol + '//' + host + pathname;
+  const query = search ? qs.parse(search.substring(1)) : undefined;
+
+  const bodyAsText = await req.text();
+  let body;
+
+  // A rough attempt to support both text and json bodies
+  try {
+    body = JSON.parse(bodyAsText);
+  } catch (err) {
+    body = bodyAsText;
+  }
+
+  return {
+    key,
+    record: {
+      method,
+      headers: headers.all(),
+      ...(body && { body }),
+      ...(query && { query }),
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ function createMSWInspector<FunctionMock extends Function>({
       // https://mswjs.io/docs/extensions/life-cycle-events#methods
       //@ts-expect-error type check seems to fail because of  SetupServer | SetupWorker union
       mockSetup.events.on('request:start', logRequest);
+      return this;
     },
 
     /**
@@ -112,6 +113,7 @@ function createMSWInspector<FunctionMock extends Function>({
      */
     clear() {
       requestLog.clear();
+      return this;
     },
 
     /**
@@ -120,8 +122,10 @@ function createMSWInspector<FunctionMock extends Function>({
     teardown() {
       //@ts-expect-error type check seems to fail because of  SetupServer | SetupWorker union
       mockSetup.events.removeListener('request:start', logRequest);
+      return this;
     },
   };
 }
 
+export type MswInspector = ReturnType<typeof createMSWInspector>;
 export { createMSWInspector };


### PR DESCRIPTION
## What kind of change does this PR introduce?

`requestMapper` receives pre evaluated `key` and `record` props.

## What is the current behaviour?

`requestMapper` must re-implement the whole default mapping logic

## What is the new behaviour?

Default mapping logic is executed and results provided to custom `requestMapper`. This allows shorter `requestMapper` implementations

## Does this PR introduce a breaking change?

Yes. `requestMapper` option receives and object of arguments.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
