### PR TITLE
chore: support msw v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.0
+
+### Breaking change
+
+- Support `msw` v2+
+- `mswInspector.getRequests` method switched from sync to async
+
 # 2.0.0
 
 ### Breaking change

--- a/README.md
+++ b/README.md
@@ -58,20 +58,20 @@ describe('My test', () => {
   it('My test', async () => {
     // Perform your tests
 
-    expect(mswInspector.getRequests('http://my.url/path')).toHaveBeenCalledWith(
-      {
-        method: 'GET',
-        headers: {
-          'my-header': 'value',
-        },
-        body: {
-          'my-body': 'value',
-        },
-        query: {
-          'my-query': 'value',
-        },
+    expect(
+      await mswInspector.getRequests('http://my.url/path'),
+    ).toHaveBeenCalledWith({
+      method: 'GET',
+      headers: {
+        'my-header': 'value',
       },
-    );
+      body: {
+        'my-body': 'value',
+      },
+      query: {
+        'my-query': 'value',
+      },
+    });
   });
 });
 ```
@@ -112,7 +112,7 @@ createMSWInspector({
 
 ### `getRequests`
 
-Returns a mocked function pre-called with all the request records whose absolute url match the provided one.
+Returns a promise returning a mocked function pre-called with all the request records whose absolute url match the provided one.
 
 The matching url can be provided as:
 
@@ -121,10 +121,10 @@ The matching url can be provided as:
 
 ```ts
 // Full string match
-mswInspector.getRequests('http://my.url/path/foo');
+await mswInspector.getRequests('http://my.url/path/foo');
 
 // Url matching patter
-mswInspector.getRequests('http://my.url/path/:param');
+await mswInspector.getRequests('http://my.url/path/:param');
 ```
 
 By default, each matching request results into a mocked function call with the following request log record:
@@ -163,7 +163,7 @@ const mswInspector = createMSWInspector({
 `getRequests` accepts an optional options object
 
 ```ts
-mswInspector.getRequests(string, {
+await mswInspector.getRequests(string, {
   debug: boolean, // Throw debug error when no matching requests found (default: true)
 });
 ```
@@ -171,7 +171,6 @@ mswInspector.getRequests(string, {
 ## Todo
 
 - Consider listening to network layer with [`@mswjs/interceptors`](https://github.com/mswjs/interceptors) and make MSW inspector usable in non-`msw` projects
-- Todo find out why `SetupServer | SetupWorker` union causes a type error in lifecycle events
 - Consider optionally returning requests not intercepted by `msw` (`request:start`/ `request:match`)
 
 [ci-badge]: https://github.com/toomuchdesign/msw-inspector/actions/workflows/ci.yml/badge.svg

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,12 @@
         "qs": "^6.11.2"
       },
       "devDependencies": {
-        "@tsconfig/node18": "^18.2.0",
+        "@tsconfig/recommended": "^1.0.3",
         "@types/jest": "^29.5.2",
         "@types/node": "^18.0.0",
         "@types/qs": "^6.9.7",
         "jest": "^29.5.0",
-        "msw": "^1.0.0",
+        "msw": "^2.0.0",
         "prettier": "^3.0.0",
         "simple-git-hooks": "^2.0.0",
         "ts-jest": "^29.1.0",
@@ -28,7 +28,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "msw": "^1.0.0"
+        "msw": "^2.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -618,6 +618,33 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/js-levenshtein": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
+      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
+      "dev": true,
+      "dependencies": {
+        "js-levenshtein": "^1.1.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1001,50 +1028,51 @@
       }
     },
     "node_modules/@mswjs/cookies": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
-      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
       "dev": true,
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
-      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
       "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
-        "headers-polyfill": "3.2.5",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
+        "strict-event-emitter": "^0.5.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/@mswjs/interceptors/node_modules/strict-event-emitter": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
-      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
       "dev": true,
       "dependencies": {
-        "events": "^3.3.0"
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
       }
     },
     "node_modules/@open-draft/until": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
-      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
     "node_modules/@sinclair/typebox": {
@@ -1071,10 +1099,10 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@tsconfig/node18": {
-      "version": "18.2.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
-      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
+    "node_modules/@tsconfig/recommended": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.3.tgz",
+      "integrity": "sha512-+jby/Guq9H8O7NWgCv6X8VAiQE8Dr/nccsCtL74xyHKhu2Knu5EAKmOZj3nLCnLm1KooUzKY+5DsnGVqhM8/wQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -1123,15 +1151,6 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
-    },
-    "node_modules/@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/ms": "*"
-      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -1182,12 +1201,6 @@
       "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
       "dev": true
     },
-    "node_modules/@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "18.16.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.17.tgz",
@@ -1200,19 +1213,16 @@
       "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
       "dev": true
     },
-    "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.3.tgz",
-      "integrity": "sha512-7QhnH7bi+6KAhBB+Auejz1uV9DHiopZqu7LfR/5gZZTkejJV5nYeZZpgfFoE0N8aDsXuiYpfKyfyMatCwQhyTQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.4.tgz",
+      "integrity": "sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -1229,22 +1239,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -1305,18 +1299,6 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-jest": {
@@ -1612,9 +1594,9 @@
       ]
     },
     "node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1793,9 +1775,9 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -1967,15 +1949,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2102,15 +2075,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "dependencies": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2230,18 +2194,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -2299,25 +2251,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/headers-polyfill": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
-      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
       "dev": true
     },
     "node_modules/html-escaper": {
@@ -2436,22 +2373,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2468,18 +2389,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -2519,21 +2428,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -2582,21 +2476,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-      "dev": true,
-      "dependencies": {
-        "which-typed-array": "^1.1.11"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -3479,29 +3358,31 @@
       "dev": true
     },
     "node_modules/msw": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
-      "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.11.tgz",
+      "integrity": "sha512-dAXFS2DxZX0uFqMPhS3oUAu8S/5IQ5qKKSwtXl3/dMTeML0C8JfSvbeWtowYg6pu4Iehgp5L/pHLrlIcG++y/A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.10",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "^4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
         "graphql": "^16.8.1",
-        "headers-polyfill": "3.2.5",
+        "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
         "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.4.3",
+        "strict-event-emitter": "^0.5.0",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -3509,14 +3390,14 @@
         "msw": "cli/index.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x <= 5.2.x"
+        "typescript": ">= 4.7.x <= 5.2.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3547,48 +3428,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "dev": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4057,12 +3896,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
-      "dev": true
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -4165,10 +3998,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/strict-event-emitter": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
-      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true
     },
     "node_modules/string_decoder": {
@@ -4480,19 +4322,6 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4537,18 +4366,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dev": true,
-      "dependencies": {
-        "util": "^0.12.3"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "0.9.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4562,25 +4379,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
-      "dev": true,
-      "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/wrap-ansi": {
@@ -5123,6 +4921,33 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "requires": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "@bundled-es-modules/js-levenshtein": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
+      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
+      "dev": true,
+      "requires": {
+        "js-levenshtein": "^1.1.6"
+      }
+    },
+    "@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "requires": {
+        "statuses": "^2.0.1"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -5426,46 +5251,45 @@
       }
     },
     "@mswjs/cookies": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
-      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
-      "dev": true,
-      "requires": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.1.0.tgz",
+      "integrity": "sha512-0ZcCVQxifZmhwNBoQIrystCb+2sWBY2Zw8lpfJBPCHGCA/HWqehITeCRVIv4VMy8MPlaHo2w2pTHFV2pFfqKPw==",
+      "dev": true
     },
     "@mswjs/interceptors": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.10.tgz",
-      "integrity": "sha512-N8x7eSLGcmUFNWZRxT1vsHvypzIRgQYdG0rJey/rZCy6zT/30qDt8Joj7FxzGNLSwXbeZqJOMqDurp7ra4hgbw==",
+      "version": "0.25.13",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.25.13.tgz",
+      "integrity": "sha512-xfjR81WwXPHwhDbqJRHlxYmboJuiSaIKpP4I5TJVFl/EmByOU13jOBT9hmEnxcjR3jvFYoqoNKt7MM9uqerj9A==",
       "dev": true,
       "requires": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
-        "headers-polyfill": "3.2.5",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
-      },
-      "dependencies": {
-        "strict-event-emitter": {
-          "version": "0.2.8",
-          "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
-          "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
-          "dev": true,
-          "requires": {
-            "events": "^3.3.0"
-          }
-        }
+        "strict-event-emitter": "^0.5.1"
+      }
+    },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
       }
     },
     "@open-draft/until": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
-      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
     "@sinclair/typebox": {
@@ -5492,10 +5316,10 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "@tsconfig/node18": {
-      "version": "18.2.2",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.2.tgz",
-      "integrity": "sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==",
+    "@tsconfig/recommended": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.3.tgz",
+      "integrity": "sha512-+jby/Guq9H8O7NWgCv6X8VAiQE8Dr/nccsCtL74xyHKhu2Knu5EAKmOZj3nLCnLm1KooUzKY+5DsnGVqhM8/wQ==",
       "dev": true
     },
     "@types/babel__core": {
@@ -5544,15 +5368,6 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
-    },
-    "@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "dev": true,
-      "requires": {
-        "@types/ms": "*"
-      }
     },
     "@types/graceful-fs": {
       "version": "4.1.6",
@@ -5603,12 +5418,6 @@
       "integrity": "sha512-qC4bCqYGy1y/NP7dDVr7KJarn+PbX1nSpwA7JXdu0HxT3QYjO8MJ+cntENtHFVy2dRAyBV23OZ6MxsW1AM1L8g==",
       "dev": true
     },
-    "@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
-    },
     "@types/node": {
       "version": "18.16.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.17.tgz",
@@ -5621,19 +5430,16 @@
       "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
       "dev": true
     },
-    "@types/set-cookie-parser": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.3.tgz",
-      "integrity": "sha512-7QhnH7bi+6KAhBB+Auejz1uV9DHiopZqu7LfR/5gZZTkejJV5nYeZZpgfFoE0N8aDsXuiYpfKyfyMatCwQhyTQ==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/statuses": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.4.tgz",
+      "integrity": "sha512-eqNDvZsCNY49OAXB0Firg/Sc2BgoWsntsLUdybGFOhAfCD6QJ2n9HXUIHGqt5qjrxmMv4wS8WLAw43ZkKcJ8Pw==",
       "dev": true
     },
     "@types/yargs": {
@@ -5650,19 +5456,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
-    },
-    "@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
-      "dev": true
-    },
-    "@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "dev": true,
-      "optional": true
     },
     "ansi-escapes": {
       "version": "4.3.2",
@@ -5706,12 +5499,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true
     },
     "babel-jest": {
       "version": "29.7.0",
@@ -5905,9 +5692,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -6032,9 +5819,9 @@
       "dev": true
     },
     "cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
       "dev": true
     },
     "create-jest": {
@@ -6151,12 +5938,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true
-    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -6255,15 +6036,6 @@
         "path-exists": "^4.0.0"
       }
     },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6346,15 +6118,6 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
-    "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
-    },
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6391,19 +6154,10 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
     },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
     "headers-polyfill": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-3.2.5.tgz",
-      "integrity": "sha512-tUCGvt191vNSQgttSyJoibR+VO+I6+iCHIUdhzEMJKE+EAL8BwCN7fUOZlY4ofOelNHsK+gEjxB/B+9N3EWtdA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.2.tgz",
+      "integrity": "sha512-EWGTfnTqAO2L/j5HZgoM/3z82L7necsJ0pO9Tp0X1wil3PDLrkypTBRgVO2ExehEEvUycejZD3FuRaXpZZc3kw==",
       "dev": true
     },
     "html-escaper": {
@@ -6487,16 +6241,6 @@
         "through": "^2.3.6"
       }
     },
-    "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6511,12 +6255,6 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true
     },
     "is-core-module": {
       "version": "2.13.0",
@@ -6544,15 +6282,6 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
-    },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
     },
     "is-glob": {
       "version": "4.0.3",
@@ -6586,15 +6315,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
-    },
-    "is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-      "dev": true,
-      "requires": {
-        "which-typed-array": "^1.1.11"
-      }
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -7267,28 +6987,30 @@
       "dev": true
     },
     "msw": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-1.3.2.tgz",
-      "integrity": "sha512-wKLhFPR+NitYTkQl5047pia0reNGgf0P6a1eTnA5aNlripmiz0sabMvvHcicE8kQ3/gZcI0YiPFWmYfowfm3lA==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.0.11.tgz",
+      "integrity": "sha512-dAXFS2DxZX0uFqMPhS3oUAu8S/5IQ5qKKSwtXl3/dMTeML0C8JfSvbeWtowYg6pu4Iehgp5L/pHLrlIcG++y/A==",
       "dev": true,
       "requires": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.10",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.1.0",
+        "@mswjs/interceptors": "^0.25.13",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "^4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
         "graphql": "^16.8.1",
-        "headers-polyfill": "3.2.5",
+        "headers-polyfill": "^4.0.1",
         "inquirer": "^8.2.0",
         "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
-        "node-fetch": "^2.6.7",
         "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.4.3",
+        "strict-event-emitter": "^0.5.0",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -7312,39 +7034,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
-      "dev": true,
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-          "dev": true
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-          "dev": true
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-          "dev": true,
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7678,12 +7367,6 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
-    "set-cookie-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
-      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==",
-      "dev": true
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -7764,10 +7447,16 @@
         "escape-string-regexp": "^2.0.0"
       }
     },
+    "statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true
+    },
     "strict-event-emitter": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.4.6.tgz",
-      "integrity": "sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true
     },
     "string_decoder": {
@@ -7958,19 +7647,6 @@
         "picocolors": "^1.0.0"
       }
     },
-    "util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -8014,16 +7690,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dev": true,
-      "requires": {
-        "@zxing/text-encoding": "0.9.0",
-        "util": "^0.12.3"
-      }
-    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8031,19 +7697,6 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -36,19 +36,19 @@
   "author": "Andrea Carraro <me@andreacarraro.it>",
   "license": "ISC",
   "devDependencies": {
-    "@tsconfig/node18": "^18.2.0",
+    "@tsconfig/recommended": "^1.0.3",
     "@types/jest": "^29.5.2",
     "@types/node": "^18.0.0",
     "@types/qs": "^6.9.7",
     "jest": "^29.5.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "prettier": "^3.0.0",
     "simple-git-hooks": "^2.0.0",
     "ts-jest": "^29.1.0",
     "typescript": "^5.1.3"
   },
   "peerDependencies": {
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "simple-git-hooks": {
     "pre-commit": "npm run test:source"

--- a/src/__tests__/__mocks__/handlers.ts
+++ b/src/__tests__/__mocks__/handlers.ts
@@ -1,19 +1,19 @@
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 export const handlers = [
-  rest.get('http://origin.com', (req, res, ctx) => {
-    return res(ctx.status(200));
+  http.get('http://origin.com', () => {
+    return HttpResponse.json({ status: 200 });
   }),
 
-  rest.get('http://origin.com/path/:param', (req, res, ctx) => {
-    return res(ctx.status(200));
+  http.get('http://origin.com/path/:param', () => {
+    return HttpResponse.json({ status: 200 });
   }),
 
-  rest.get('http://origin.com:1234/path/:param', (req, res, ctx) => {
-    return res(ctx.status(200));
+  http.get('http://origin.com:1234/path/:param', () => {
+    return HttpResponse.json({ status: 200 });
   }),
 
-  rest.post('http://origin.com/path/:param', (req, res, ctx) => {
-    return res(ctx.status(200));
+  http.post('http://origin.com/path/:param', () => {
+    return HttpResponse.json({ status: 200 });
   }),
 ];

--- a/src/__tests__/defaultRequestLogger.test.ts
+++ b/src/__tests__/defaultRequestLogger.test.ts
@@ -28,14 +28,13 @@ describe('default request logger', () => {
     { body: 'Plain text', expectedBody: 'Plain text', type: 'text' },
   ])('body as $type', ({ body, expectedBody, type }) => {
     it('returns expected body value', async () => {
-      // @ts-expect-error fetch not typed in Node18
       await fetch(`http://origin.com/path/param`, {
         method: 'POST',
         body,
       });
 
       expect(
-        mswInspector.getRequests('http://origin.com/path/param'),
+        await mswInspector.getRequests('http://origin.com/path/param'),
       ).toHaveBeenCalledWith({
         method: 'POST',
         headers: {
@@ -54,7 +53,6 @@ describe('default request logger', () => {
         object: 'object[prop1]=value1&object[prop2]=value2',
       };
 
-      // @ts-expect-error fetch not typed in Node18
       await fetch(
         `http://origin.com/path/param?${queryString.string}&${queryString.array}&${queryString.object}`,
         {
@@ -63,7 +61,7 @@ describe('default request logger', () => {
       );
 
       expect(
-        mswInspector.getRequests('http://origin.com/path/param'),
+        await mswInspector.getRequests('http://origin.com/path/param'),
       ).toHaveBeenCalledWith({
         method: 'POST',
         headers: {},
@@ -85,14 +83,13 @@ describe('default request logger', () => {
         header1: 'header-1',
         header2: 'header-2',
       };
-      // @ts-expect-error fetch not typed in Node18
       await fetch(`http://origin.com/path/param`, {
         method: 'POST',
         headers,
       });
 
       expect(
-        mswInspector.getRequests('http://origin.com/path/param'),
+        await mswInspector.getRequests('http://origin.com/path/param'),
       ).toHaveBeenCalledWith({
         method: 'POST',
         headers,
@@ -103,9 +100,8 @@ describe('default request logger', () => {
 
 describe('invalid url provided', () => {
   it('throw invalid url error', async () => {
-    // @ts-expect-error fetch not typed in Node18
     await fetch('http://origin.com/path/param');
-    expect(() => mswInspector.getRequests('invalid-path')).toThrow(
+    expect(mswInspector.getRequests('invalid-path')).rejects.toThrowError(
       '[msw-inspector] Provided path is invalid: invalid-path. Intercepted requests paths are:\n\nhttp://origin.com',
     );
   });
@@ -113,11 +109,10 @@ describe('invalid url provided', () => {
 
 describe('no matching calls', () => {
   it('throw expected error', async () => {
-    // @ts-expect-error fetch not typed in Node18
     await fetch('http://origin.com/path/param');
-    expect(() =>
+    expect(
       mswInspector.getRequests('http://it.was.never.called/'),
-    ).toThrow(
+    ).rejects.toThrowError(
       '[msw-inspector] Cannot find a matching requests for path: http://it.was.never.called/. Intercepted requests paths are:\n\nhttp://origin.com',
     );
   });

--- a/src/__tests__/getRequests.test.ts
+++ b/src/__tests__/getRequests.test.ts
@@ -22,27 +22,25 @@ describe('getRequests', () => {
   describe('path matching', () => {
     describe('origin with or without trailing slash', () => {
       it('find matching request', async () => {
-        // @ts-expect-error fetch not typed in Node18
         await fetch('http://origin.com');
+
         expect(
-          mswInspector.getRequests('http://origin.com'),
+          await mswInspector.getRequests('http://origin.com'),
         ).toHaveBeenCalledTimes(1);
         expect(
-          mswInspector.getRequests('http://origin.com/'),
+          await mswInspector.getRequests('http://origin.com/'),
         ).toHaveBeenCalledTimes(1);
       });
     });
 
     describe('multiple matching calls', () => {
       it('preserves calls order', async () => {
-        // @ts-expect-error fetch not typed in Node18
         await fetch('http://origin.com', { headers: { id: 'first' } });
-        // @ts-expect-error fetch not typed in Node18
         await fetch('http://origin.com', { headers: { id: 'second' } });
-        // @ts-expect-error fetch not typed in Node18
         await fetch('http://origin.com', { headers: { id: 'third' } });
 
-        const matchingCalls = mswInspector.getRequests('http://origin.com');
+        const matchingCalls =
+          await mswInspector.getRequests('http://origin.com');
         expect(matchingCalls).toHaveBeenCalledTimes(3);
 
         ['first', 'second', 'third'].forEach((id, index) => {
@@ -59,30 +57,27 @@ describe('getRequests', () => {
     describe('url with port', () => {
       it('returns requests', async () => {
         const path = 'http://origin.com:1234/path/param';
-        // @ts-expect-error fetch not typed in Node18
         await fetch(path);
-        expect(mswInspector.getRequests(path)).toHaveBeenCalledTimes(1);
+        expect(await mswInspector.getRequests(path)).toHaveBeenCalledTimes(1);
       });
     });
 
     describe('matching patterns', () => {
       describe('multiple :namedParams', () => {
         it('find matching request', async () => {
-          // @ts-expect-error fetch not typed in Node18
           await fetch('http://origin.com/path/param');
           expect(
-            mswInspector.getRequests('http://origin.com/:param1/:param2'),
+            await mswInspector.getRequests('http://origin.com/:param1/:param2'),
           ).toHaveBeenCalledTimes(1);
         });
       });
 
       describe('less :namedParams then actual paths segments', () => {
         it('throw expected error', async () => {
-          // @ts-expect-error fetch not typed in Node18
           await fetch('http://origin.com/path/param');
-          expect(() =>
+          expect(
             mswInspector.getRequests('http://origin.com/:param1/'),
-          ).toThrow(
+          ).rejects.toThrowError(
             '[msw-inspector] Cannot find a matching requests for path: http://origin.com/:param1/. Intercepted requests paths are:\n\nhttp://origin.com',
           );
         });
@@ -90,10 +85,9 @@ describe('getRequests', () => {
 
       describe('wildcard (.*)', () => {
         it('find matching request', async () => {
-          // @ts-expect-error fetch not typed in Node18
           await fetch('http://origin.com/path/param');
           expect(
-            mswInspector.getRequests('http://origin.com/(.*)'),
+            await mswInspector.getRequests('http://origin.com/(.*)'),
           ).toHaveBeenCalledTimes(1);
         });
       });
@@ -101,9 +95,8 @@ describe('getRequests', () => {
 
     describe('invalid url provided', () => {
       it('throw invalid url error', async () => {
-        // @ts-expect-error fetch not typed in Node18
         await fetch('http://origin.com/path/param');
-        expect(() => mswInspector.getRequests('invalid-path')).toThrow(
+        expect(mswInspector.getRequests('invalid-path')).rejects.toThrowError(
           '[msw-inspector] Provided path is invalid: invalid-path. Intercepted requests paths are:\n\nhttp://origin.com',
         );
       });
@@ -111,21 +104,19 @@ describe('getRequests', () => {
 
     describe('requesting a url never called', () => {
       it('throw debug error', async () => {
-        // @ts-expect-error fetch not typed in Node18
         await fetch('http://origin.com/path/param');
-        expect(() =>
+        expect(
           mswInspector.getRequests('http://it.was.never.called'),
-        ).toThrow(
+        ).rejects.toThrowError(
           '[msw-inspector] Cannot find a matching requests for path: http://it.was.never.called. Intercepted requests paths are:\n\nhttp://origin.com',
         );
       });
 
       describe('"debug" option === false', () => {
         it('returns empty mock', async () => {
-          // @ts-expect-error fetch not typed in Node18
           await fetch('http://origin.com/path/param');
           expect(
-            mswInspector.getRequests('http://it.was.never.called', {
+            await mswInspector.getRequests('http://it.was.never.called', {
               debug: false,
             }),
           ).not.toHaveBeenCalled();
@@ -137,15 +128,14 @@ describe('getRequests', () => {
     if (process.env.CI) {
       describe('calling and requesting a url not registered as MSW handler', () => {
         it('throw expected error', async () => {
-          // @ts-expect-error fetch not typed in Node18
           await fetch(
             'https://api.github.com/repos/toomuchdesign/msw-inspector',
           );
-          expect(() =>
+          expect(
             mswInspector.getRequests(
               'https://api.github.com/repos/toomuchdesign/msw-inspector',
             ),
-          ).toThrow(
+          ).rejects.toThrowError(
             '[msw-inspector] Cannot find a matching requests for path: https://api.github.com/repos/toomuchdesign/msw-inspector.',
           );
         });

--- a/src/__tests__/requestLoggerOption.test.ts
+++ b/src/__tests__/requestLoggerOption.test.ts
@@ -33,14 +33,13 @@ afterAll(() => {
 
 describe('"requestLogger" option', () => {
   it('replaces default request record', async () => {
-    // @ts-expect-error fetch not typed in Node18
     await fetch('http://origin.com/path/param', {
       method: 'POST',
       body: JSON.stringify({ surname: 'bar' }),
     });
 
     expect(
-      mswInspector.getRequests('http://origin.com/path/param'),
+      await mswInspector.getRequests('http://origin.com/path/param'),
     ).toHaveBeenCalledWith({
       method: 'POST',
       customBodyProp: { surname: 'bar' },

--- a/src/defaultRequestLogger.ts
+++ b/src/defaultRequestLogger.ts
@@ -1,5 +1,4 @@
 import qs, { ParsedQs } from 'qs';
-import type { MockedRequest } from 'msw';
 
 export type DefaultRequestRecord = {
   method: string;
@@ -9,10 +8,10 @@ export type DefaultRequestRecord = {
 };
 
 export async function defaultRequestLogger(
-  req: MockedRequest,
+  request: Request,
 ): Promise<DefaultRequestRecord> {
-  const { method, headers, url } = req;
-  const { search } = url;
+  const { method, headers, url } = request;
+  const { search } = new URL(url);
   const query = search ? qs.parse(search.substring(1)) : undefined;
 
   /**
@@ -21,14 +20,14 @@ export async function defaultRequestLogger(
    */
   let body;
   try {
-    body = await req.json();
+    body = await request.clone().json();
   } catch (err) {
-    body = await req.clone().text();
+    body = await request.clone().text();
   }
 
   return {
     method,
-    headers: headers.all(),
+    headers: Object.fromEntries(headers),
     ...(body && { body }),
     ...(query && { query }),
   };

--- a/src/makeErrorMessage.ts
+++ b/src/makeErrorMessage.ts
@@ -1,11 +1,11 @@
 export function makeErrorMessage({
   message,
-  requestLogs,
+  interceptedRequests,
 }: {
   message: string;
-  requestLogs: Map<string, unknown>;
+  interceptedRequests: Map<string, Request[]>;
 }): string {
-  const availablePaths = Array.from(requestLogs.keys());
+  const availablePaths = Array.from(interceptedRequests.keys());
   return `[msw-inspector] ${message}. Intercepted requests paths are:\n\n${availablePaths.join(
     '\n',
   )}`;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json",
+  "extends": "@tsconfig/recommended/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "noErrorTruncation": true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor

## What is the current behaviour?

Only `msw` v1 supported

## What is the new behaviour?

Only `msw` v2 supported

## Does this PR introduce a breaking change?

Yes, due to the new `msw` v2 implementation, `requestLogger` and `mswInspector.getRequests` methods are now async.

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [X] Docs have been added / updated
