### PR TITLE
feat: improve error message when request.body is already read

### DIFF
--- a/src/__tests__/__mocks__/handlers.ts
+++ b/src/__tests__/__mocks__/handlers.ts
@@ -16,4 +16,8 @@ export const handlers = [
   http.post('http://origin.com/path/:param', () => {
     return HttpResponse.json({ status: 200 });
   }),
+
+  http.get('http://origin.com/non-json-response', () => {
+    return new HttpResponse({ status: 404 });
+  }),
 ];

--- a/src/__tests__/__mocks__/handlers.ts
+++ b/src/__tests__/__mocks__/handlers.ts
@@ -20,4 +20,9 @@ export const handlers = [
   http.get('http://origin.com/non-json-response', () => {
     return new HttpResponse({ status: 404 });
   }),
+
+  http.post('http://origin.com/used-body', async ({ request }) => {
+    const body = await request.json();
+    return HttpResponse.json(body, { status: 200 });
+  }),
 ];

--- a/src/__tests__/defaultRequestLogger.test.ts
+++ b/src/__tests__/defaultRequestLogger.test.ts
@@ -86,6 +86,19 @@ describe('default request logger', () => {
     });
   });
 
+  describe('non-json response', () => {
+    it('returns expected call', async () => {
+      await fetch('http://origin.com/non-json-response');
+
+      expect(
+        await mswInspector.getRequests('http://origin.com/non-json-response'),
+      ).toHaveBeenCalledWith({
+        method: 'GET',
+        headers: {},
+      });
+    });
+  });
+
   describe('headers', () => {
     it('returns expected header object', async () => {
       const headers = {
@@ -105,24 +118,24 @@ describe('default request logger', () => {
       });
     });
   });
-});
 
-describe('invalid url provided', () => {
-  it('throw invalid url error', async () => {
-    await fetch('http://origin.com/path/param');
-    expect(mswInspector.getRequests('invalid-path')).rejects.toThrowError(
-      '[msw-inspector] Provided path is invalid: invalid-path. Intercepted requests paths are:\n\nhttp://origin.com',
-    );
+  describe('invalid url provided', () => {
+    it('throw invalid url error', async () => {
+      await fetch('http://origin.com/path/param');
+      expect(mswInspector.getRequests('invalid-path')).rejects.toThrowError(
+        '[msw-inspector] Provided path is invalid: invalid-path. Intercepted requests paths are:\n\nhttp://origin.com',
+      );
+    });
   });
-});
 
-describe('no matching calls', () => {
-  it('throw expected error', async () => {
-    await fetch('http://origin.com/path/param');
-    expect(
-      mswInspector.getRequests('http://it.was.never.called/'),
-    ).rejects.toThrowError(
-      '[msw-inspector] Cannot find a matching requests for path: http://it.was.never.called/. Intercepted requests paths are:\n\nhttp://origin.com',
-    );
+  describe('no matching calls', () => {
+    it('throw expected error', async () => {
+      await fetch('http://origin.com/path/param');
+      expect(
+        mswInspector.getRequests('http://it.was.never.called/'),
+      ).rejects.toThrowError(
+        '[msw-inspector] Cannot find a matching requests for path: http://it.was.never.called/. Intercepted requests paths are:\n\nhttp://origin.com',
+      );
+    });
   });
 });

--- a/src/__tests__/defaultRequestLogger.test.ts
+++ b/src/__tests__/defaultRequestLogger.test.ts
@@ -138,4 +138,19 @@ describe('default request logger', () => {
       );
     });
   });
+
+  describe('body already used by MSW handler', () => {
+    it('throw expected error', async () => {
+      await fetch('http://origin.com/used-body', {
+        method: 'POST',
+        body: JSON.stringify({ hello: 'world' }),
+      });
+
+      expect(
+        mswInspector.getRequests('http://origin.com/used-body'),
+      ).rejects.toThrowError(
+        '[msw-inspector] request.body already read. Make sure your msw handlers clone the request with "request.clone()" before they read the body.',
+      );
+    });
+  });
 });

--- a/src/defaultRequestLogger.ts
+++ b/src/defaultRequestLogger.ts
@@ -1,4 +1,5 @@
 import qs, { ParsedQs } from 'qs';
+import { makeErrorMessage } from './makeErrorMessage';
 
 export type DefaultRequestRecord = {
   method: string;
@@ -10,6 +11,12 @@ export type DefaultRequestRecord = {
 export async function defaultRequestLogger(
   request: Request,
 ): Promise<DefaultRequestRecord> {
+  if (request.bodyUsed) {
+    throw new Error(
+      '[msw-inspector] request.body already read. Make sure your msw handlers clone the request with "request.clone()" before they read the body.',
+    );
+  }
+
   const { method, headers, url } = request;
   const { search } = new URL(url);
   const query = search ? qs.parse(search.substring(1)) : undefined;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behaviour?

`msw` handlers reading request body cause `msw-inspector` calls to throw a cryptic `Error: unusable` error.

## What is the new behaviour?

Check if body is used and throw a more descriptive error if the case.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [X] Tests for the changes have been added
- [ ] Docs have been added / updated
