### PR TITLE
Inplement request matching using regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The matching url can be provided as:
 
 - plain absolute url string
 - [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) matching pattern
+- regular expression (also matches against query string)
 
 ```ts
 // Full string match
@@ -134,6 +135,9 @@ await mswInspector.getRequests('http://my.url/path/foo');
 
 // Url matching patter
 await mswInspector.getRequests('http://my.url/path/:param');
+
+// Url regular expression
+await mswInspector.getRequests('http://.+/path/');
 ```
 
 By default, each matching request results into a mocked function call with the following request log record:

--- a/src/__tests__/getRequests.test.ts
+++ b/src/__tests__/getRequests.test.ts
@@ -103,6 +103,15 @@ describe('getRequests', () => {
       });
     });
 
+    describe('matching regexp', () => {
+      it('find matching request', async () => {
+        await fetch('http://origin.com/path/param?query=value');
+        expect(
+          await mswInspector.getRequests(/.+\?query=.+/),
+        ).toHaveBeenCalledTimes(1);
+      });
+    });
+
     describe('invalid url provided', () => {
       it('throw invalid url error', async () => {
         await fetch('http://origin.com/path/param');


### PR DESCRIPTION
## What kind of change does this PR introduce?

Implements #200 

## What is the current behaviour?

We can only match against url path and need to provide a hostname.

## What is the new behaviour?

We can match against any part of the request url using a regular expression.

## Does this PR introduce a breaking change?

No

## Other information:

## Please check if the PR fulfills these requirements:

- [x] Tests for the changes have been added
- [x] Docs have been added / updated
