### PR TITLE
docs: specify path-to-regexp version

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ await mswInspector.getRequests('http://my.url/path/foo');
 
 // path-to-regexp v7 url matching pattern
 await mswInspector.getRequests('http://my.url/path/:param');
+await mswInspector.getRequests('http://my.url/path/*');
 
 // Full url regular expression match
 await mswInspector.getRequests(/.+\?query=.+/);

--- a/README.md
+++ b/README.md
@@ -125,15 +125,15 @@ Returns a promise returning a mocked function pre-called with all the request re
 
 The matching url can be provided as:
 
-- plain absolute url string
-- [path-to-regexp](https://www.npmjs.com/package/path-to-regexp) matching pattern
-- regular expression (also matches against query string)
+- Full string match
+- [path-to-regexp v7](https://github.com/pillarjs/path-to-regexp/tree/v7.2.0) url matching pattern
+- Full url regular expression match (matching against query string, too)
 
 ```ts
 // Full string match
 await mswInspector.getRequests('http://my.url/path/foo');
 
-// Url matching pattern
+// path-to-regexp v7 url matching pattern
 await mswInspector.getRequests('http://my.url/path/:param');
 
 // Full url regular expression match

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -3,7 +3,7 @@ import { defineConfig, defaultInclude } from 'vitest/config';
 export default defineConfig({
   test: {
     setupFiles: ['vitest.setup.ts'],
-    testTimeout: 200,
+    testTimeout: process.env.CI ? 1000 : 200,
     coverage: {
       provider: 'v8',
       include: ['src'],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behaviour?

You can also link to an open issue here.

## What is the new behaviour?

...

## Does this PR introduce a breaking change?

What changes might users need to make in their application due to this PR?

## Other information:

## Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added
- [ ] Docs have been added / updated
